### PR TITLE
EE-9410 Fixed Feedback CSV export to contain "Why Not?" data

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/FeedbackResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/FeedbackResource.java
@@ -1,7 +1,6 @@
 package uk.gov.digital.ho.pttg.api;
 
 import com.google.gson.Gson;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -40,15 +39,15 @@ public class FeedbackResource {
 
     private FeedbackCsvView buildCsvView(FeedbackDto f) {
         Gson mapper = new Gson();
-        FeedbackDetail detail = mapper.fromJson(f.getDetail().replace("\"whynot\": {},", ""), FeedbackDetail.class);
-        String whynot = detail.getWhynot() != null ? detail.getWhynot().replace("-", " ") : "";
+        FeedbackDetail detail = mapper.fromJson(f.getDetail().replace("\"reasonForNotMatch\": {},", ""), FeedbackDetail.class);
+        String reasonForNotMatch = detail.getReasonForNotMatch() != null ? detail.getReasonForNotMatch().replace("-", " ") : "";
         final String formattedTimestamp = f.getTimestamp() !=null ? DateTimeFormatter.ofPattern(CSV_DATE_FORMAT).withLocale(Locale.ENGLISH).format(f.getTimestamp()) : "";
         return FeedbackCsvView.builder()
                 .timestamp(formattedTimestamp)
                 .nino(detail.getNino())
                 .userId(f.getUserId())
                 .match(detail.getMatch())
-                .whynot(whynot)
+                .reasonForNotMatch(reasonForNotMatch)
                 .matchOther(detail.getMatchOther())
                 .build();
     }

--- a/src/main/java/uk/gov/digital/ho/pttg/csv/CsvView.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/csv/CsvView.java
@@ -24,7 +24,7 @@ public class CsvView extends AbstractCsvView {
     private static final String MAPPING_TIMESTAMP = "timestamp";
     private static final String MAPPING_NINO = "nino";
     private static final String MAPPING_MATCH = "match";
-    private static final String MAPPING_WHYNOT = "whynot";
+    private static final String MAPPING_WHYNOT = "reasonForNotMatch";
     private static final String MAPPING_MATCH_OTHER = "matchOther";
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/pttg/dto/FeedbackCsvView.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/dto/FeedbackCsvView.java
@@ -15,7 +15,7 @@ public class FeedbackCsvView {
     private String userId;
     private String nino;
     private String match;
-    private String whynot;
+    private String reasonForNotMatch;
     private String matchOther;
 
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/dto/FeedbackDetail.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/dto/FeedbackDetail.java
@@ -11,7 +11,7 @@ public class FeedbackDetail {
 
     private String nino;
     private String match;
-    private String whynot;
+    private String reasonForNotMatch;
     private String matchOther;
 
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/FeedbackResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/FeedbackResourceTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.verify;
@@ -31,9 +30,9 @@ public class FeedbackResourceTest {
     private static final String USER_ID = "me";
     private static final String UUID = "uuid";
     private static final String NAMESPACE = "env";
-    private static final String DETAIL_NO_WHY_NOT_SECTION = "{\"nino\": \"JD123456C\", \"match\": \"yes\"}";
-    private static final String DETAIL = "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"whynot\": \"fail-b-nonsalaried\", \"matchOther\": \"test2\"}";
-    private static final String DETAIL_BUGGY_WHYNOT = "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"whynot\": {}, \"matchOther\": \"test2\"}";
+    private static final String DETAIL_NO_REASON_FOR_NOT_MATCH_SECTION = "{\"nino\": \"JD123456C\", \"match\": \"yes\"}";
+    private static final String DETAIL = "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"reasonForNotMatch\": \"fail-b-nonsalaried\", \"matchOther\": \"test2\"}";
+    private static final String DETAIL_BUGGY_REASON_FOR_NOT_MATCH = "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"reasonForNotMatch\": {}, \"matchOther\": \"test2\"}";
     private static LocalDateTime NOW = LocalDateTime.now();
     private static LocalDateTime NOW_PLUS_60_MINS = LocalDateTime.now().plusMinutes(60);
 
@@ -65,7 +64,7 @@ public class FeedbackResourceTest {
     }
 
     private List<FeedbackDto> buildFeedbackList() {
-        return ImmutableList.of(createFeedback(NOW, DETAIL), createFeedback(NOW_PLUS_60_MINS, DETAIL_NO_WHY_NOT_SECTION), createFeedback(NOW, DETAIL_BUGGY_WHYNOT));
+        return ImmutableList.of(createFeedback(NOW, DETAIL), createFeedback(NOW_PLUS_60_MINS, DETAIL_NO_REASON_FOR_NOT_MATCH_SECTION), createFeedback(NOW, DETAIL_BUGGY_REASON_FOR_NOT_MATCH));
     }
 
     private FeedbackDto createFeedback(LocalDateTime timestamp, String detail) {
@@ -82,40 +81,40 @@ public class FeedbackResourceTest {
 
     private List<FeedbackCsvView> buildFeedbackViewList() {
         List<FeedbackCsvView> views = new ArrayList<>();
-        views.add(createFeedbackViewWithWhyNotSection(NOW));
-        views.add(createFeedbackViewWithoutWhyNotSection(NOW_PLUS_60_MINS));
-        views.add(createFeedbackViewWithBuggyWhyNotSection(NOW));
+        views.add(createFeedbackViewWithReasonForNotMatchSection(NOW));
+        views.add(createFeedbackViewWithoutReasonForNotMatchSection(NOW_PLUS_60_MINS));
+        views.add(createFeedbackViewWithBuggyReasonForNotMatchSection(NOW));
         return views;
     }
 
-    private FeedbackCsvView createFeedbackViewWithoutWhyNotSection(LocalDateTime timestamp) {
+    private FeedbackCsvView createFeedbackViewWithoutReasonForNotMatchSection(LocalDateTime timestamp) {
         return FeedbackCsvView.builder()
                 .timestamp(DateTimeFormatter.ofPattern(CSV_DATE_FORMAT).format(timestamp))
                 .userId(USER_ID)
                 .nino("JD123456C")
                 .match("yes")
-                .whynot("")
+                .reasonForNotMatch("")
                 .build();
     }
 
-    private FeedbackCsvView createFeedbackViewWithWhyNotSection(LocalDateTime timestamp) {
+    private FeedbackCsvView createFeedbackViewWithReasonForNotMatchSection(LocalDateTime timestamp) {
         return FeedbackCsvView.builder()
                 .timestamp(DateTimeFormatter.ofPattern(CSV_DATE_FORMAT).format(timestamp))
                 .userId(USER_ID)
                 .match("yes")
                 .nino("JB557733D")
                 .matchOther("test2")
-                .whynot("fail b nonsalaried")
+                .reasonForNotMatch("fail b nonsalaried")
                 .build();
     }
 
-    private FeedbackCsvView createFeedbackViewWithBuggyWhyNotSection(LocalDateTime timestamp) {
+    private FeedbackCsvView createFeedbackViewWithBuggyReasonForNotMatchSection(LocalDateTime timestamp) {
         return FeedbackCsvView.builder()
                 .timestamp(DateTimeFormatter.ofPattern(CSV_DATE_FORMAT).format(timestamp))
                 .userId(USER_ID)
                 .match("yes")
                 .nino("JB557733D")
-                .whynot("")
+                .reasonForNotMatch("")
                 .matchOther("test2")
                 .build();
     }

--- a/src/test/resources/resourceIntTest.json
+++ b/src/test/resources/resourceIntTest.json
@@ -11,6 +11,6 @@
     "timestamp": "2017-09-12T14:45:48.000",
     "sessionId": "somesessionid",
     "userId": "james.nail@digital.homeoffice.gov.uk",
-    "detail": "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"whynot\": \"failed-b-nonsalaried\", \"matchOther\": \"test2\"}"
+    "detail": "{\"nino\": \"JB557733D\", \"match\": \"yes\", \"reasonForNotMatch\": \"failed-b-nonsalaried\", \"matchOther\": \"test2\"}"
   }
 ]


### PR DESCRIPTION
Updated the Feedback CSV export to expect the reason for not matching response to be stored in the database as 'reasonForNotMatch' not 'whynot' (in the detail column json).